### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ for xmega-specific libs.<br>
 The files in this directory tree are likely to be derived from the Arduino IDE headers
 and implementation for standard Arduino libraries.  To avoid collision, and avoid
 problems with software upgrades, you should copy these to your private 'sketchbook'
-libraries directory.  Assuming your sketchbook is '~/sketchbook', the contents of
-this directory would be copied to '~/sketchbook/libraries/'.<br>
+libraries directory.  Assuming your sketchbook is `~/sketchbook`, the contents of
+this directory would be copied to `~/sketchbook/libraries/`. You can find the location
+of your sketchbook directory in the Arduino IDE at **File > Preferences > Sketchbook
+location**<br>
 <br>
 the following libraries are included:<br>
 <br>


### PR DESCRIPTION
- Fix Markdown to avoid unintentional strikeout of text.
- Add instructions for finding the sketchbook directory.

### Before:
![clipboard01](https://user-images.githubusercontent.com/8572152/45085706-3a182f00-b0b6-11e8-99e6-d1b208d01175.png)
---

### After:
![clipboard02](https://user-images.githubusercontent.com/8572152/45085723-3e444c80-b0b6-11e8-8ae6-1f5ee39ef930.png)
